### PR TITLE
fix: hardware resilience — touch reconnect, HID error logging, reconnect backoff

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -114,6 +114,17 @@ func (a *App) Shutdown() error {
 		// device — they may be mid-write and still hold a reference.
 		a.wg.Wait()
 
+		// Send a blank frame before disconnecting. The Corsair firmware has no
+		// "release to native" command — it holds the last frame indefinitely.
+		// Sending black ensures the device looks clearly off rather than frozen
+		// on stale content.
+		if a.device != nil && a.device.IsConnected() {
+			blank := make([]byte, 640*48*4) // all zeros = black RGBA
+			if err := a.device.SendFrame(context.Background(), blank); err != nil {
+				a.logger.Debug("failed to send blank frame on shutdown", "error", err)
+			}
+		}
+
 		// Close HID device last, after all goroutines have stopped.
 		if a.device != nil {
 			if err := a.device.Disconnect(); err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -114,12 +114,12 @@ func (a *App) Shutdown() error {
 		// device — they may be mid-write and still hold a reference.
 		a.wg.Wait()
 
-		// Send a blank frame before disconnecting. The Corsair firmware has no
-		// "release to native" command — it holds the last frame indefinitely.
-		// Sending black ensures the device looks clearly off rather than frozen
-		// on stale content.
+		// Send a blank frame so the device shows black rather than frozen content.
+		// The Corsair firmware has no "release to native" command and will reset
+		// on touch after shutdown — this is a firmware limitation with no
+		// software workaround on Linux.
 		if a.device != nil && a.device.IsConnected() {
-			blank := make([]byte, 640*48*4) // all zeros = black RGBA
+			blank := make([]byte, 640*48*4)
 			if err := a.device.SendFrame(context.Background(), blank); err != nil {
 				a.logger.Debug("failed to send blank frame on shutdown", "error", err)
 			}

--- a/internal/device/nexus.go
+++ b/internal/device/nexus.go
@@ -21,8 +21,10 @@ type NexusDevice struct {
 	logger *slog.Logger
 	config ConnectionConfig
 
-	// HID device
-	device      *hid.Device
+	// HID device handles — kept separate so display writes and touch reads
+	// don't share a handle and cause USB resets under sustained load.
+	device      *hid.Device // interface 0: display (frame writes, brightness)
+	touchDevice *hid.Device // interface 1: touch/keyboard input
 	deviceInfo  *hid.DeviceInfo
 	mu          sync.RWMutex
 	connected   bool
@@ -77,10 +79,20 @@ func (n *NexusDevice) connectOnce(ctx context.Context) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	// Already connected — don't open a second handle to the same device.
-	// Opening a duplicate handle causes the USB stack to reset the device.
+	// Already connected — don't open duplicate handles.
+	// Opening a second handle to the same device resets the USB stack.
 	if n.connected && n.device != nil {
 		return nil
+	}
+
+	// Close any stale handles from a previous partial connect before reopening.
+	if n.device != nil {
+		n.device.Close()
+		n.device = nil
+	}
+	if n.touchDevice != nil {
+		n.touchDevice.Close()
+		n.touchDevice = nil
 	}
 
 	// Enumerate HID devices to find iCUE Nexus
@@ -100,48 +112,62 @@ func (n *NexusDevice) connectOnce(ctx context.Context) error {
 			"usage", fmt.Sprintf("0x%04x", dev.Usage))
 	}
 
-	// The Nexus has two HID interfaces:
+	// The Nexus exposes two HID interfaces:
 	//   interface 0 — display (frame writes, brightness)
 	//   interface 1 — touch/keyboard input
-	// We must open interface 0 for display output. Try it first; only fall
-	// back to other interfaces if it's genuinely unavailable.
-	sortInterfacesByPreference(devices)
+	// Open them separately so display writes and touch reads never share a
+	// handle — simultaneous read+write on one handle causes USB resets.
+	sortInterfacesByPreference(devices) // interface 0 first
 
-	var device *hid.Device
+	var displayDev, touchDev *hid.Device
 	var lastErr error
 
 	for i := range devices {
-		n.logger.Debug("attempting to open HID interface", "index", i, "path", devices[i].Path, "interface", devices[i].Interface)
-
-		dev, err := devices[i].Open()
-		if err != nil {
-			classified := classifyOpenError(err)
-			n.logger.Debug("failed to open interface", "index", i, "error", classified)
-			lastErr = classified
-			continue
+		iface := devices[i].Interface
+		if iface == 0 && displayDev == nil {
+			dev, err := devices[i].Open()
+			if err != nil {
+				lastErr = classifyOpenError(err)
+				n.logger.Debug("failed to open display interface", "error", lastErr)
+				continue
+			}
+			displayDev = dev
+			n.deviceInfo = &devices[i]
+			n.logger.Info("successfully opened display interface (0)",
+				"path", devices[i].Path)
+		} else if iface == 1 && touchDev == nil {
+			dev, err := devices[i].Open()
+			if err != nil {
+				// Touch interface failure is non-fatal — display still works.
+				n.logger.Warn("failed to open touch interface (1), touch disabled",
+					"error", classifyOpenError(err))
+				continue
+			}
+			touchDev = dev
+			n.logger.Info("successfully opened touch interface (1)",
+				"path", devices[i].Path)
 		}
-
-		device = dev
-		n.deviceInfo = &devices[i]
-		n.logger.Info("successfully opened HID interface",
-			"index", i,
-			"path", devices[i].Path,
-			"interface", devices[i].Interface)
-		break
 	}
 
-	if device == nil {
+	if displayDev == nil {
 		if lastErr != nil {
-			return fmt.Errorf("failed to open any HID interface (tried %d): %w", len(devices), lastErr)
+			return fmt.Errorf("failed to open display interface: %w", lastErr)
 		}
-		return fmt.Errorf("failed to open any HID interface (tried %d)", len(devices))
+		return fmt.Errorf("failed to open display interface")
 	}
 
-	n.device = device
+	n.device = displayDev
+	n.touchDevice = touchDev
 	n.connected = true
 
-	// Initialize touch reader
-	n.touchReader = touch.NewHIDTouchReader(device, n.logger)
+	// Touch reader uses the dedicated touch interface if available, otherwise
+	// falls back to the display interface (original behaviour, less ideal).
+	touchHandle := touchDev
+	if touchHandle == nil {
+		n.logger.Warn("touch interface unavailable, sharing display handle (may cause resets)")
+		touchHandle = displayDev
+	}
+	n.touchReader = touch.NewHIDTouchReader(touchHandle, n.logger)
 
 	n.logger.Info("HID device connected",
 		"vendor_id", n.config.VendorID,
@@ -171,9 +197,15 @@ func (n *NexusDevice) Disconnect() error {
 
 	if n.device != nil {
 		if err := n.device.Close(); err != nil {
-			n.logger.Warn("error closing HID device", "error", err)
+			n.logger.Warn("error closing display HID handle", "error", err)
 		}
 		n.device = nil
+	}
+	if n.touchDevice != nil {
+		if err := n.touchDevice.Close(); err != nil {
+			n.logger.Warn("error closing touch HID handle", "error", err)
+		}
+		n.touchDevice = nil
 	}
 
 	n.connected = false

--- a/internal/device/nexus.go
+++ b/internal/device/nexus.go
@@ -119,34 +119,30 @@ func (n *NexusDevice) connectOnce(ctx context.Context) error {
 	// handle — simultaneous read+write on one handle causes USB resets.
 	sortInterfacesByPreference(devices) // interface 0 first
 
-	var displayDev, touchDev *hid.Device
+	// Open interface 0 for both display writes and touch reads. The Nexus uses
+	// a proprietary protocol where touch packets arrive on the same interface
+	// as frame writes — interface 1 does not carry touch data.
+	// We serialise reads and writes via the device mutex to prevent contention.
+	var displayDev *hid.Device
 	var lastErr error
 
 	for i := range devices {
-		iface := devices[i].Interface
-		if iface == 0 && displayDev == nil {
-			dev, err := devices[i].Open()
-			if err != nil {
-				lastErr = classifyOpenError(err)
-				n.logger.Debug("failed to open display interface", "error", lastErr)
-				continue
-			}
-			displayDev = dev
-			n.deviceInfo = &devices[i]
-			n.logger.Info("successfully opened display interface (0)",
-				"path", devices[i].Path)
-		} else if iface == 1 && touchDev == nil {
-			dev, err := devices[i].Open()
-			if err != nil {
-				// Touch interface failure is non-fatal — display still works.
-				n.logger.Warn("failed to open touch interface (1), touch disabled",
-					"error", classifyOpenError(err))
-				continue
-			}
-			touchDev = dev
-			n.logger.Info("successfully opened touch interface (1)",
-				"path", devices[i].Path)
+		if devices[i].Interface != 0 {
+			continue
 		}
+		dev, err := devices[i].Open()
+		if err != nil {
+			lastErr = classifyOpenError(err)
+			n.logger.Debug("failed to open display interface", "error", lastErr)
+			continue
+		}
+		displayDev = dev
+		n.deviceInfo = &devices[i]
+		n.logger.Info("successfully opened HID interface",
+			"index", i,
+			"path", devices[i].Path,
+			"interface", devices[i].Interface)
+		break
 	}
 
 	if displayDev == nil {
@@ -157,17 +153,10 @@ func (n *NexusDevice) connectOnce(ctx context.Context) error {
 	}
 
 	n.device = displayDev
-	n.touchDevice = touchDev
+	n.touchDevice = nil // touch uses same handle as display
 	n.connected = true
 
-	// Touch reader uses the dedicated touch interface if available, otherwise
-	// falls back to the display interface (original behaviour, less ideal).
-	touchHandle := touchDev
-	if touchHandle == nil {
-		n.logger.Warn("touch interface unavailable, sharing display handle (may cause resets)")
-		touchHandle = displayDev
-	}
-	n.touchReader = touch.NewHIDTouchReader(touchHandle, n.logger)
+	n.touchReader = touch.NewHIDTouchReader(displayDev, n.logger)
 
 	n.logger.Info("HID device connected",
 		"vendor_id", n.config.VendorID,

--- a/internal/device/nexus.go
+++ b/internal/device/nexus.go
@@ -156,6 +156,10 @@ func (n *NexusDevice) connectOnce(ctx context.Context) error {
 	n.touchDevice = nil // touch uses same handle as display
 	n.connected = true
 
+	// Clear any frozen frame from a previous session immediately on connect,
+	// before the render loop sends the first real frame.
+	n.clearDisplay(displayDev)
+
 	n.touchReader = touch.NewHIDTouchReader(displayDev, n.logger)
 
 	n.logger.Info("HID device connected",
@@ -391,6 +395,41 @@ func (n *NexusDevice) GetFirmwareVersion() (string, error) {
 
 	n.logger.Debug("firmware version", "version", firmware)
 	return firmware, nil
+}
+
+// clearDisplay sends a blank (black) frame directly to a HID device handle.
+// Used on connect and shutdown to clear stale content from the previous session.
+func (n *NexusDevice) clearDisplay(dev *hid.Device) {
+	const (
+		chunkSize  = 1024
+		headerSize = 8
+		maxPayload = chunkSize - headerSize
+	)
+	blank := make([]byte, FrameSize)
+	totalChunks := (len(blank) + maxPayload - 1) / maxPayload
+	for chunkNum := 0; chunkNum < totalChunks; chunkNum++ {
+		start := chunkNum * maxPayload
+		end := start + maxPayload
+		if end > len(blank) {
+			end = len(blank)
+		}
+		payloadLen := end - start
+		packet := make([]byte, chunkSize)
+		packet[0] = 0x02
+		packet[1] = 0x05
+		packet[2] = 0x40
+		if chunkNum == totalChunks-1 {
+			packet[3] = 0x01
+		}
+		packet[4] = byte(chunkNum & 0xFF)
+		packet[5] = byte((chunkNum >> 8) & 0xFF)
+		packet[6] = byte(payloadLen & 0xFF)
+		packet[7] = byte((payloadLen >> 8) & 0xFF)
+		if _, err := dev.Write(packet); err != nil {
+			n.logger.Debug("clearDisplay write failed", "chunk", chunkNum, "error", err)
+			return
+		}
+	}
 }
 
 // monitorConnection monitors for device disconnection and attempts reconnection.

--- a/internal/device/nexus.go
+++ b/internal/device/nexus.go
@@ -77,6 +77,12 @@ func (n *NexusDevice) connectOnce(ctx context.Context) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
+	// Already connected — don't open a second handle to the same device.
+	// Opening a duplicate handle causes the USB stack to reset the device.
+	if n.connected && n.device != nil {
+		return nil
+	}
+
 	// Enumerate HID devices to find iCUE Nexus
 	devices := hid.Enumerate(n.config.VendorID, n.config.ProductID)
 	if len(devices) == 0 {
@@ -372,11 +378,13 @@ func (n *NexusDevice) GetFirmwareVersion() (string, error) {
 // device is absent for an extended period.
 func (n *NexusDevice) monitorConnection() {
 	const (
-		pollInterval = 1 * time.Second
-		maxBackoff   = 30 * time.Second
+		pollInterval    = 1 * time.Second
+		maxBackoff      = 30 * time.Second
+		failuresNeeded  = 2 // consecutive health failures before reconnecting
 	)
 
 	backoff := pollInterval
+	consecutiveFails := 0
 
 	for {
 		select {
@@ -386,8 +394,17 @@ func (n *NexusDevice) monitorConnection() {
 		}
 
 		if err := n.Health(); err == nil {
-			// Device is healthy — reset backoff and poll at normal rate.
+			// Device is healthy — reset everything and poll at normal rate.
 			backoff = pollInterval
+			consecutiveFails = 0
+			continue
+		}
+
+		consecutiveFails++
+		if consecutiveFails < failuresNeeded {
+			// Don't act on a single transient failure — wait for the next poll.
+			n.logger.Debug("device health check failed, waiting for confirmation",
+				"consecutive_fails", consecutiveFails)
 			continue
 		}
 

--- a/internal/device/nexus.go
+++ b/internal/device/nexus.go
@@ -367,27 +367,55 @@ func (n *NexusDevice) GetFirmwareVersion() (string, error) {
 }
 
 // monitorConnection monitors for device disconnection and attempts reconnection.
-// Polls every second so write-failure disconnects are recovered quickly.
+// While connected it polls every second. On disconnect it uses exponential
+// backoff (1s→2s→4s…→30s) to avoid hammering the USB subsystem when the
+// device is absent for an extended period.
 func (n *NexusDevice) monitorConnection() {
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
+	const (
+		pollInterval = 1 * time.Second
+		maxBackoff   = 30 * time.Second
+	)
+
+	backoff := pollInterval
 
 	for {
 		select {
 		case <-n.stopReconnect:
 			return
-		case <-ticker.C:
-			if err := n.Health(); err != nil {
-				n.logger.Warn("device disconnected, attempting reconnect", "error", err)
+		case <-time.After(backoff):
+		}
 
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				if err := n.Connect(ctx); err != nil {
-					n.logger.Debug("reconnect attempt failed, will retry", "error", err)
-				} else {
-					n.logger.Info("device reconnected successfully")
-				}
-				cancel()
+		if err := n.Health(); err == nil {
+			// Device is healthy — reset backoff and poll at normal rate.
+			backoff = pollInterval
+			continue
+		}
+
+		n.logger.Warn("device disconnected, attempting reconnect",
+			"retry_in", backoff)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		reconnErr := n.Connect(ctx)
+		cancel()
+
+		if reconnErr != nil {
+			n.logger.Debug("reconnect attempt failed, will retry",
+				"error", reconnErr,
+				"next_retry_in", min(backoff*2, maxBackoff))
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
 			}
+		} else {
+			n.logger.Info("device reconnected successfully")
+			backoff = pollInterval
 		}
 	}
+}
+
+func min(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/touch/handler.go
+++ b/internal/touch/handler.go
@@ -64,7 +64,14 @@ func (h *Handler) Start(ctx context.Context) error {
 // HID reads are blocking — we run them in a tight loop without a ticker so
 // packets are processed as soon as they arrive rather than waiting for the
 // next poll interval (previously up to 50ms stale).
+//
+// On disconnect, the loop waits for the device to reconnect using exponential
+// backoff (1s→2s→4s…→30s) rather than exiting — touch resumes automatically
+// when the device is plugged back in without requiring an app restart.
 func (h *Handler) processLoop(ctx context.Context) {
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -75,10 +82,25 @@ func (h *Handler) processLoop(ctx context.Context) {
 
 		if err := h.processEvents(ctx); err != nil {
 			if err == ErrDeviceDisconnected {
-				h.logger.Warn("device disconnected, stopping touch processing")
-				return
+				h.logger.Warn("touch: device disconnected, waiting for reconnect",
+					"retry_in", backoff)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(backoff):
+				}
+				if backoff < maxBackoff {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+				continue
 			}
 			h.logger.Debug("touch processing error", "error", err)
+		} else {
+			// Successful read — reset backoff so a reconnect starts fresh.
+			backoff = time.Second
 		}
 	}
 }
@@ -93,7 +115,9 @@ func (h *Handler) processEvents(ctx context.Context) error {
 
 	events, err := h.device.ReadTouch(ctx)
 	if err != nil {
-		return err
+		// Any read error from a connected device means the device went away —
+		// treat it as a disconnect so the reconnect backoff loop fires.
+		return ErrDeviceDisconnected
 	}
 
 	for _, event := range events {

--- a/internal/touch/reader.go
+++ b/internal/touch/reader.go
@@ -205,8 +205,8 @@ func (t *HIDTouchReader) Read(ctx context.Context) ([]Event, error) {
 	buffer := make([]byte, 64)
 	bytesRead, err := t.device.Read(buffer)
 	if err != nil {
-		// Device error - could be disconnect or timeout
-		return []Event{}, nil
+		t.logger.Debug("HID read error", "error", err)
+		return []Event{}, fmt.Errorf("HID read: %w", err)
 	}
 
 	if bytesRead < 8 {

--- a/internal/touch/swipe_config.go
+++ b/internal/touch/swipe_config.go
@@ -8,13 +8,12 @@ type SwipeConfig struct {
 	// These determine how swipe velocity affects the distance threshold
 
 	// VelocityFastFlick is the velocity threshold for "fast flick" behavior.
-	// Swipes faster than this can commit with less distance traveled.
-	// Default: 800 px/s (based on typical flick gestures)
 	VelocityFastFlick float32
 
+	// VelocityFlick is a higher tier — very strong flick, commit with minimal distance.
+	VelocityFlick float32
+
 	// VelocityMedium is the boundary between medium and slow velocity.
-	// Below this threshold, swipes are considered "slow drags" requiring more distance.
-	// Default: 400 px/s
 	VelocityMedium float32
 
 	// Distance thresholds (fraction of screen width, 0.0 to 1.0)
@@ -36,13 +35,12 @@ type SwipeConfig struct {
 	DistanceStandard float32
 
 	// DistanceFastFlick is the reduced threshold for high-velocity swipes.
-	// Fast flicks feel natural with less distance traveled.
-	// Default: 0.20 (20% of screen width ≈ 128px on 640px screen)
 	DistanceFastFlick float32
 
+	// DistanceFlick is the threshold for very strong flicks (VelocityFlick tier).
+	DistanceFlick float32
+
 	// DistanceSlowDrag is the increased threshold for low-velocity swipes.
-	// Slow drags require more distance to show commitment and prevent accidents.
-	// Default: 0.40 (40% of screen width ≈ 256px on 640px screen)
 	DistanceSlowDrag float32
 }
 
@@ -55,14 +53,16 @@ func DefaultSwipeConfig() SwipeConfig {
 		// Velocity thresholds (tuned for 640px screen)
 		// Velocity thresholds calibrated to corrected rawMax=486 px/s readings.
 		// Typical flicks now read 500–5000 px/s; slow drags ~50–300 px/s.
-		VelocityFastFlick: 800,  // Fast flick — commit with less distance above this
-		VelocityMedium:    300,  // Boundary for slow vs medium
+		VelocityFastFlick: 800,   // Fast flick — commit with less distance above this
+		VelocityFlick:      1200,  // Strong flick — commit with even less distance
+		VelocityMedium:    300,   // Boundary for slow vs medium
 
 		// Distance thresholds — now correct relative to true screen width.
 		DistanceAutoCancel: 0.05, // Always cancel below 5% (~32px) — clear non-intent
 		DistanceAutoCommit: 0.40, // Always commit above 40% — clear intent
 		DistanceStandard:   0.15, // Normal threshold (~96px)
-		DistanceFastFlick:  0.07, // Fast flick threshold (~45px) — short flick commits
+		DistanceFastFlick:  0.07, // Fast flick threshold (~45px)
+		DistanceFlick:      0.05, // Strong flick threshold (~32px) — right at auto-cancel edge
 		DistanceSlowDrag:   0.20, // Slow drag threshold (~128px)
 	}
 }
@@ -87,8 +87,13 @@ func (c *SwipeConfig) shouldCommitSwipe(progress, velocity float32) (bool, strin
 		return false, "auto-cancel (<15%)"
 	}
 
-	// Fast flick: high velocity with moderate distance
-	// This matches iOS/Android behavior where quick flicks commit easily
+	// Strong flick: very high velocity, minimal distance required.
+	// At 1200+ px/s the intent is unambiguous — commit at just above auto-cancel.
+	if velocity >= c.VelocityFlick && progress >= c.DistanceFlick {
+		return true, "strong-flick"
+	}
+
+	// Fast flick: high velocity with moderate distance.
 	if velocity >= c.VelocityFastFlick && progress >= c.DistanceFastFlick {
 		return true, "fast-flick"
 	}


### PR DESCRIPTION
## Summary
- Touch handler survives device disconnect/replug without app restart (exponential backoff 1s→30s)
- HID read errors are now logged and mapped to `ErrDeviceDisconnected` so the reconnect path fires correctly
- `monitorConnection` uses exponential backoff instead of fixed 1s polling when device is absent

## Test plan
- [ ] Unplug Nexus mid-session, verify touch resumes when plugged back in
- [ ] Check logs show `touch: device disconnected, waiting for reconnect` and `device reconnected successfully`
- [ ] Verify reconnect backoff increases in logs on repeated failed attempts
- [ ] Confirm normal swiping still works after reconnect