### PR TITLE
perf: skip USB send when frame is unchanged, remove stale chunk constants

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -491,6 +491,7 @@ func (a *App) renderLoop() {
 	a.logger.Info("render loop started", "fps", targetFPS)
 
 	var frameCount int
+	var lastSentPix []byte
 	wsHub := a.apiServer.Hub()
 
 	// Pool the flate compressor internals via EncoderBufferPool so the
@@ -510,10 +511,19 @@ func (a *App) renderLoop() {
 				continue
 			}
 
-			// Send to device if connected
+			// Send to device if connected and the frame has changed.
+			// Skipping identical frames eliminates all 121 USB bulk transfers
+			// per tick at idle — the dominant cost when content is static.
 			if a.device.IsConnected() {
-				if err := a.device.SendFrame(a.ctx, frame.Pix); err != nil {
-					a.logger.Debug("failed to send frame", "error", err)
+				if !bytes.Equal(frame.Pix, lastSentPix) {
+					if err := a.device.SendFrame(a.ctx, frame.Pix); err != nil {
+						a.logger.Debug("failed to send frame", "error", err)
+					} else {
+						if len(lastSentPix) != len(frame.Pix) {
+							lastSentPix = make([]byte, len(frame.Pix))
+						}
+						copy(lastSentPix, frame.Pix)
+					}
 				}
 			}
 

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -65,6 +65,4 @@ const (
 	DisplayWidth  = 640
 	DisplayHeight = 48
 	FrameSize     = DisplayWidth * DisplayHeight * 4 // RGBA
-	ChunkSize     = 1024 * 4                         // USB transfer chunk size
-	NumChunks     = 121                              // Total chunks per frame
 )


### PR DESCRIPTION
## Summary

- Gate `SendFrame` behind `bytes.Equal` in the render loop — at idle with static content, USB transfers drop from 3,600/s to zero
- `lastSentPix` is only updated on a successful send, so USB errors retry on the next tick rather than being silently dropped
- Remove unused `ChunkSize = 1024*4` and `NumChunks = 121` constants from `device.go`; the 4 KB value was wrong (SendFrame uses 1 KB chunks) and both had no callers

## Test plan

- [ ] Build and deploy to hardware (`make install`), confirm display still updates normally during plugin refreshes and page transitions
- [ ] Confirm USB activity drops at idle (e.g. `usbmon` or `usbtop` shows near-zero transfers when no zone payload changes)
- [ ] Trigger a reconnect (unplug/replug) and confirm the first frame after reconnect sends correctly
- [ ] All existing tests pass (`make test`)