### PR TITLE
feat(editor): location typeahead + map preview, live plugin config

### DIFF
--- a/internal/api/draft_handlers.go
+++ b/internal/api/draft_handlers.go
@@ -280,9 +280,17 @@ func (s *Server) draftPatchZone(w http.ResponseWriter, r *http.Request, draft *z
 
 	// Live-preview: push changes to the running renderer immediately so
 	// the device display updates without requiring a commit first.
-	if patch.PluginConfig != nil && s.zoneNotifier != nil {
-		if err := s.zoneNotifier.BroadcastZoneConfigChange(zoneID, patch.PluginConfig); err != nil {
-			s.logger.Warn("live preview config push failed", "zone_id", zoneID, "error", err)
+	if patch.PluginConfig != nil {
+		// Persist to store so the plugin picks up the new config on restart.
+		if s.zoneCfg != nil {
+			if err := s.zoneCfg.BroadcastZoneConfigChange(zoneID, patch.PluginConfig); err != nil {
+				s.logger.Warn("zone config persist failed", "zone_id", zoneID, "error", err)
+			}
+		}
+		if s.zoneNotifier != nil {
+			if err := s.zoneNotifier.BroadcastZoneConfigChange(zoneID, patch.PluginConfig); err != nil {
+				s.logger.Warn("live preview config push failed", "zone_id", zoneID, "error", err)
+			}
 		}
 	}
 	if patch.ThemeOverride != nil && s.layoutReloader != nil {

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -8,11 +8,12 @@ import "time"
 type FieldType string
 
 const (
-	FieldTypeString FieldType = "string"
-	FieldTypeEnum   FieldType = "enum"
-	FieldTypeInt    FieldType = "int"
-	FieldTypeBool   FieldType = "bool"
-	FieldTypeColor  FieldType = "color"
+	FieldTypeString   FieldType = "string"
+	FieldTypeEnum     FieldType = "enum"
+	FieldTypeInt      FieldType = "int"
+	FieldTypeBool     FieldType = "bool"
+	FieldTypeColor    FieldType = "color"
+	FieldTypeLocation FieldType = "location"
 )
 
 // FieldOption is a single selectable value for an enum field.

--- a/plugins/weather/plugin.go
+++ b/plugins/weather/plugin.go
@@ -41,12 +41,11 @@ func (m *WeatherPlugin) Describe() (plugin.Descriptor, error) {
 		Schema: plugin.ConfigSchema{
 			Fields: []plugin.ConfigField{
 				{
-					Key: "location", Label: "Location", Type: plugin.FieldTypeString, Default: "Jersey City, NJ",
-					Help: "City name or 'lat,lon' coordinates",
-				},
-				{
 					Key: "unit", Label: "Units", Type: plugin.FieldTypeEnum, Default: "imperial",
 					Options: []plugin.FieldOption{{Value: "imperial", Label: "°F"}, {Value: "metric", Label: "°C"}},
+				},
+				{
+					Key: "location", Label: "Location", Type: plugin.FieldTypeLocation, Default: "Jersey City, NJ",
 				},
 			},
 		},

--- a/ui/lib/src/models/api_models.dart
+++ b/ui/lib/src/models/api_models.dart
@@ -29,7 +29,6 @@ class DisplayConfig with _$DisplayConfig {
 @freezed
 class NexusConfig with _$NexusConfig {
   const factory NexusConfig({
-    @Default('Jersey City') String location,
     @JsonKey(name: 'time_format') @Default('24h') String timeFormat,
     @Default('imperial') String unit,
     @JsonKey(name: 'background_color') @Default('#000000') String backgroundColor,

--- a/ui/lib/src/models/settings_state.dart
+++ b/ui/lib/src/models/settings_state.dart
@@ -58,7 +58,6 @@ class SettingsState extends ChangeNotifier {
     notifyListeners();
   }
 
-  String get location => _config?.location ?? '';
   String get timeFormat => _config?.timeFormat ?? '24h';
   String get unit => _config?.unit ?? 'imperial';
   String get backgroundColor => _config?.backgroundColor ?? '#000000';
@@ -138,7 +137,6 @@ class SettingsState extends ChangeNotifier {
   /// Update configuration locally.
   /// Only the fields you pass are changed; others keep their current value.
   void updateConfig({
-    String? location,
     String? timeFormat,
     String? unit,
     String? backgroundColor,
@@ -155,7 +153,6 @@ class SettingsState extends ChangeNotifier {
         : _config!.display;
 
     _config = _config!.copyWith(
-      location: location ?? _config!.location,
       timeFormat: timeFormat ?? _config!.timeFormat,
       unit: unit ?? _config!.unit,
       backgroundColor: backgroundColor ?? _config!.backgroundColor,
@@ -165,11 +162,6 @@ class SettingsState extends ChangeNotifier {
       display: display,
     );
     notifyListeners();
-  }
-
-  /// Set location
-  void setLocation(String value) {
-    updateConfig(location: value);
   }
 
   /// Set time format

--- a/ui/lib/src/widgets.dart
+++ b/ui/lib/src/widgets.dart
@@ -1,2 +1,1 @@
 export 'widgets/maps/world_map.dart';
-export 'widgets/settings/tabs/location_tab.dart';

--- a/ui/lib/src/widgets/onboarding/onboarding_overlay.dart
+++ b/ui/lib/src/widgets/onboarding/onboarding_overlay.dart
@@ -4,10 +4,9 @@ import 'package:provider/provider.dart';
 import '../../models/settings_state.dart';
 import '../../theme/app_tokens.dart';
 import '../common/common.dart';
-import '../settings/tabs/location_tab.dart';
 
 /// Full-screen onboarding shown on first launch.
-/// Steps: Welcome → Connect → Location → Done.
+/// Steps: Welcome → Connect → Done.
 class OnboardingOverlay extends StatefulWidget {
   const OnboardingOverlay({super.key});
 
@@ -17,7 +16,7 @@ class OnboardingOverlay extends StatefulWidget {
 
 class _OnboardingOverlayState extends State<OnboardingOverlay> {
   int _step = 0;
-  static const int _totalSteps = 4;
+  static const int _totalSteps = 3;
 
   void _next() => setState(() => _step++);
 
@@ -61,8 +60,7 @@ class _OnboardingOverlayState extends State<OnboardingOverlay> {
     switch (_step) {
       case 0: return _WelcomeStep(onNext: _next);
       case 1: return _ConnectStep(onNext: _next);
-      case 2: return _LocationStep(onNext: _next);
-      case 3: return _DoneStep(onFinish: _finish);
+      case 2: return _DoneStep(onFinish: _finish);
       default: return const SizedBox.shrink();
     }
   }
@@ -425,79 +423,6 @@ class _CodeBlock extends StatelessWidget {
           color: AppColors.accent,
         ),
       ),
-    );
-  }
-}
-
-class _LocationStep extends StatelessWidget {
-  const _LocationStep({required this.onNext});
-  final VoidCallback onNext;
-
-  @override
-  Widget build(BuildContext context) {
-    final settings = context.watch<SettingsState>();
-
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(
-              AppSpacing.xl, AppSpacing.xxl, AppSpacing.xl, 0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  color: AppColors.accent.withValues(alpha: 0.10),
-                  borderRadius: AppRadius.smBr,
-                  border: Border.all(
-                    color: AppColors.accent.withValues(alpha: 0.25),
-                    width: 1,
-                  ),
-                ),
-                child: const Icon(Icons.location_on_outlined,
-                    size: AppIconSize.xl, color: AppColors.accent),
-              ),
-              const SizedBox(height: AppSpacing.lg),
-              Text(
-                'LOCATION',
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: AppColors.accent,
-                  letterSpacing: 1.5,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Text('Choose your location',
-                  style: Theme.of(context).textTheme.headlineMedium),
-              const SizedBox(height: AppSpacing.sm),
-              Text(
-                'Used for the weather plugin. You can change this later.',
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
-              ),
-              const SizedBox(height: AppSpacing.md),
-            ],
-          ),
-        ),
-        Expanded(
-          child: LocationTab(
-            onLocationSelected: (loc) => settings.updateConfig(location: loc),
-            initialLocation: settings.location,
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(
-              AppSpacing.xl, AppSpacing.sm, AppSpacing.xl, AppSpacing.lg),
-          child: NexusButton.primary(
-            label: 'Continue',
-            onPressed: onNext,
-            expand: true,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/ui/lib/src/widgets/settings/tabs/editor_configuration.dart
+++ b/ui/lib/src/widgets/settings/tabs/editor_configuration.dart
@@ -364,6 +364,10 @@ class _SchemaField extends StatelessWidget {
             _toInt(currentValue) ?? _toInt(field.defaultValue) ?? 0;
         return _IntField(
             value: val, min: field.min, max: field.max, onChanged: onChanged);
+      case 'location':
+        final val =
+            currentValue as String? ?? field.defaultValue as String? ?? '';
+        return _LocationField(value: val, onChanged: (v) => onChanged(v));
       default:
         final val =
             currentValue as String? ?? field.defaultValue as String? ?? '';
@@ -531,4 +535,133 @@ class _StringFieldStatefulState extends State<_StringFieldStateful> {
         ),
         onSubmitted: widget.onChanged,
       );
+}
+
+// ── Location field: typeahead + map preview ───────────────────────────────────
+
+class _LocationField extends StatefulWidget {
+  const _LocationField({required this.value, required this.onChanged});
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_LocationField> createState() => _LocationFieldState();
+}
+
+class _LocationFieldState extends State<_LocationField> {
+  late final TextEditingController _ctrl;
+  final _mapController = MapController();
+  Place? _selectedPlace;
+
+  static const _defaultLat = 40.7128;
+  static const _defaultLon = -74.0060;
+  static const _defaultZoom = 4.0;
+  static const _selectedZoom = 11.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = TextEditingController(text: widget.value);
+    if (widget.value.isNotEmpty) _resolveInitial(widget.value);
+  }
+
+  @override
+  void didUpdateWidget(_LocationField old) {
+    super.didUpdateWidget(old);
+    if (old.value != widget.value && _ctrl.text != widget.value) {
+      _ctrl.text = widget.value;
+      _resolveInitial(widget.value);
+    }
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _resolveInitial(String query) async {
+    final results = await LocationService.searchPlaces(query);
+    if (!mounted || results.isEmpty) return;
+    setState(() => _selectedPlace = results.first);
+    _mapController.move(
+      LatLng(results.first.latitude, results.first.longitude),
+      _selectedZoom,
+    );
+  }
+
+  void _selectPlace(Place place) {
+    final display = LocationService.getDisplayString(place);
+    _ctrl.text = display;
+    setState(() => _selectedPlace = place);
+    widget.onChanged(display);
+    _mapController.move(
+      LatLng(place.latitude, place.longitude),
+      _selectedZoom,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final lat = _selectedPlace?.latitude ?? _defaultLat;
+    final lon = _selectedPlace?.longitude ?? _defaultLon;
+    final zoom = _selectedPlace != null ? _selectedZoom : _defaultZoom;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TypeAheadField<Place>(
+          textFieldConfiguration: TextFieldConfiguration(
+            controller: _ctrl,
+            style: theme.textTheme.bodySmall,
+            decoration: const InputDecoration(
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              border: OutlineInputBorder(),
+              hintText: 'Search places…',
+            ),
+          ),
+          suggestionsCallback: LocationService.searchPlaces,
+          itemBuilder: (_, Place place) => ListTile(
+            dense: true,
+            title: Text(
+              LocationService.getDisplayString(place),
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
+          onSuggestionSelected: _selectPlace,
+          noItemsFoundBuilder: (_) => Padding(
+            padding: const EdgeInsets.all(8),
+            child: Text('No places found', style: theme.textTheme.bodySmall),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        ClipRRect(
+          borderRadius: AppRadius.smBr,
+          child: SizedBox(
+            height: 240,
+            child: WorldMap(
+              latitude: lat,
+              longitude: lon,
+              width: double.infinity,
+              zoom: zoom,
+              controller: _mapController,
+              mapColor: cs.onSurface,
+              indicatorColor: AppColors.accent,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: 3),
+          child: Text(
+            '© OpenStreetMap contributors',
+            style: theme.textTheme.labelSmall
+                ?.copyWith(color: cs.onSurfaceVariant, fontSize: 8),
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/ui/lib/src/widgets/settings/tabs/editor_tab.dart
+++ b/ui/lib/src/widgets/settings/tabs/editor_tab.dart
@@ -2,12 +2,18 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import '../../../models/api_models.dart';
+import '../../../models/place.dart';
+import '../../../services/location_service.dart';
 import '../../../services/nexus_api_service.dart';
 import '../../../services/ws_service.dart';
 import '../../../theme/app_tokens.dart';
 import '../../common/common.dart';
+import '../../maps/world_map.dart';
 
 part 'editor_helpers.dart';
 part 'editor_zone_row.dart';
@@ -298,15 +304,11 @@ class _EditorTabState extends State<EditorTab> {
                         onReorder: _reorderZones,
                         onNavigate: _navigatePage,
                         catalogFor: _catalogFor,
-                      ),
-                    ),
-                    const VerticalDivider(width: 1),
-                    SizedBox(
-                      width: 260,
-                      child: _Configuration(
-                        zone: _selectedZone,
-                        catalog: _catalogFor(_selectedZone?.plugin ?? ''),
-                        onPatch: _patchZone,
+                        configuration: _Configuration(
+                          zone: _selectedZone,
+                          catalog: _catalogFor(_selectedZone?.plugin ?? ''),
+                          onPatch: _patchZone,
+                        ),
                       ),
                     ),
                   ],

--- a/ui/lib/src/widgets/settings/tabs/editor_zone_row.dart
+++ b/ui/lib/src/widgets/settings/tabs/editor_zone_row.dart
@@ -31,6 +31,7 @@ class _ZonePage extends StatelessWidget {
     required this.onReorder,
     required this.onNavigate,
     required this.catalogFor,
+    this.configuration,
   });
 
   final LayoutPage? page;
@@ -43,6 +44,7 @@ class _ZonePage extends StatelessWidget {
   final ValueChanged<List<String>> onReorder;
   final ValueChanged<int> onNavigate;
   final PluginCatalogEntry? Function(String) catalogFor;
+  final Widget? configuration;
 
   @override
   Widget build(BuildContext context) {
@@ -129,36 +131,40 @@ class _ZonePage extends StatelessWidget {
               ),
             ),
           ),
-          // Fill remaining height with a drop target so plugins can be
-          // dropped anywhere in the middle column, not just on the zone strip.
-          Expanded(
-            child: DragTarget<String>(
-              onWillAcceptWithDetails: (d) => zones.length < 6,
-              onAcceptWithDetails: (d) => onDropPlugin(d.data),
-              builder: (ctx, candidates, _) => candidates.isNotEmpty
-                  ? Container(
-                      margin: const EdgeInsets.only(top: AppSpacing.sm),
-                      decoration: BoxDecoration(
-                        color: AppColors.accent.withValues(alpha: 0.06),
-                        borderRadius: AppRadius.smBr,
-                        border: Border.all(
-                          color: AppColors.accent.withValues(alpha: 0.4),
-                          style: BorderStyle.solid,
-                        ),
-                      ),
-                      child: Center(
-                        child: Text(
-                          'Drop to add',
-                          style: theme.textTheme.labelSmall?.copyWith(
-                            fontSize: 10,
-                            color: AppColors.accent,
+          // Configuration panel for the selected zone, shown below the strip.
+          if (configuration != null) ...[
+            Divider(height: 1, color: theme.colorScheme.outline),
+            Expanded(child: configuration!),
+          ] else
+            // Fallback: fill remaining space as a drop target when no zone is selected.
+            Expanded(
+              child: DragTarget<String>(
+                onWillAcceptWithDetails: (d) => zones.length < 6,
+                onAcceptWithDetails: (d) => onDropPlugin(d.data),
+                builder: (ctx, candidates, _) => candidates.isNotEmpty
+                    ? Container(
+                        margin: const EdgeInsets.only(top: AppSpacing.sm),
+                        decoration: BoxDecoration(
+                          color: AppColors.accent.withValues(alpha: 0.06),
+                          borderRadius: AppRadius.smBr,
+                          border: Border.all(
+                            color: AppColors.accent.withValues(alpha: 0.4),
+                            style: BorderStyle.solid,
                           ),
                         ),
-                      ),
-                    )
-                  : const SizedBox.expand(),
+                        child: Center(
+                          child: Text(
+                            'Drop to add',
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              fontSize: 10,
+                              color: AppColors.accent,
+                            ),
+                          ),
+                        ),
+                      )
+                    : const SizedBox.expand(),
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/ui/lib/src/widgets/settings/tabs/global_tab.dart
+++ b/ui/lib/src/widgets/settings/tabs/global_tab.dart
@@ -1,13 +1,10 @@
-// Global tab — display defaults, background images, and location.
+// Global tab — display defaults and background images.
 // These write directly to POST /api/config — no draft needed.
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../../../models/settings_state.dart';
 import '../../../theme/app_tokens.dart';
 import 'display_tab.dart';
 import 'images_tab.dart';
-import 'location_tab.dart';
 
 class GlobalTab extends StatefulWidget {
   const GlobalTab({super.key});
@@ -19,7 +16,7 @@ class GlobalTab extends StatefulWidget {
 class _GlobalTabState extends State<GlobalTab> with SingleTickerProviderStateMixin {
   late final TabController _tabs;
 
-  static const _labels = ['Display', 'Images', 'Location'];
+  static const _labels = ['Display', 'Images'];
 
   @override
   void initState() {
@@ -54,16 +51,9 @@ class _GlobalTabState extends State<GlobalTab> with SingleTickerProviderStateMix
         Expanded(
           child: TabBarView(
             controller: _tabs,
-            children: [
-              const DisplayTab(),
-              const ImagesTab(),
-              Builder(builder: (ctx) {
-                final settings = ctx.watch<SettingsState>();
-                return LocationTab(
-                  onLocationSelected: (loc) => settings.updateConfig(location: loc),
-                  initialLocation: settings.location,
-                );
-              }),
+            children: const [
+              DisplayTab(),
+              ImagesTab(),
             ],
           ),
         ),

--- a/ui/lib/src/widgets/settings/tabs/plugins_tab.dart
+++ b/ui/lib/src/widgets/settings/tabs/plugins_tab.dart
@@ -50,7 +50,6 @@ class _PluginsTabState extends State<PluginsTab> {
       sublabel: 'Conditions',
       icon: Icons.cloud,
       keys: [
-        _ConfigKey('location', 'Location', _ControlType.text),
         _ConfigKey('unit', 'Unit', _ControlType.dropdown,
             options: ['metric', 'imperial']),
       ],
@@ -342,7 +341,7 @@ class _PluginCardState extends State<_PluginCard> {
 
 // ── Data model helpers ────────────────────────────────────────────────────────
 
-enum _ControlType { dropdown, text }
+enum _ControlType { dropdown }
 
 class _ConfigKey {
   final String id;

--- a/ui/test/widget_test.dart
+++ b/ui/test/widget_test.dart
@@ -128,7 +128,6 @@ void main() {
       final state = SettingsState(apiService: svc);
       await state.loadFromBackend();
 
-      expect(state.location, 'Tokyo');
       expect(state.timeFormat, '12h');
       expect(state.dateFormat, 'DD/MM/YYYY');
 
@@ -143,9 +142,9 @@ void main() {
       await state.loadFromBackend();
 
       final originalTime = state.timeFormat;
-      state.updateConfig(location: 'Paris');
+      state.updateConfig(unit: 'metric');
 
-      expect(state.location, 'Paris');
+      expect(state.unit, 'metric');
       expect(state.timeFormat, originalTime); // unchanged
     });
   });


### PR DESCRIPTION
## Summary

- **`FieldTypeLocation`** added to plugin type system; weather plugin declares its location field with this type (Units ordered above Location)
- **Global location removed** from `NexusConfig`, `SettingsState`, onboarding flow, and Global tab — location is now purely a per-plugin `plugin_config` field on plugins that need it
- **Editor config panel** relocated from fixed right column to below the zone strip, expanding with the selected zone's schema
- **Location field UI**: `TypeAheadField` backed by Nominatim OSM search + 240px `flutter_map` preview that animates to the selected place; no API key required
- **Bug fix**: `plugin_config` draft patches now also persist to the store (via `zoneCfg.BroadcastZoneConfigChange`) so config survives plugin process restarts — previously only the live sampler was updated, losing changes on restart
- Fixed stale widget tests referencing the removed `location` field on `SettingsState`

## Test plan

- [ ] Select weather zone in editor → config panel shows Units dropdown then Location typeahead below the strip
- [ ] Type a city name in Location → Nominatim suggestions appear; selecting one updates the map and the hardware display immediately
- [ ] Restart the weather plugin process → location config persists (read from store on reconnect)
- [ ] Other plugin zones (CPU, GPU, Network) show their schema fields correctly with no location field
- [ ] Onboarding flow completes in 3 steps (Welcome → Connect → Done), no Location step
- [ ] Global tab has Display and Images tabs only